### PR TITLE
Filter out image-only emojis based on their file name. #3

### DIFF
--- a/workflow/main.rb
+++ b/workflow/main.rb
@@ -22,6 +22,15 @@ def emoji_item(emoji)
   }
 end
 
+def is_image_only(emoji)
+  if emoji.image_filename == "#{emoji.name}.png"
+      is_image = true
+  else
+      is_image = false
+  end
+  is_image
+end
+
 Alfred.with_friendly_error do |alfred|
   fb = alfred.feedback
 
@@ -29,7 +38,7 @@ Alfred.with_friendly_error do |alfred|
     query = Regexp.escape(ARGV.first)
 
     items = Emoji.all.map(&:name).grep(/#{query}/).each do |code|
-      fb.add_item(emoji_item(Emoji.find_by_alias(code)))
+      fb.add_item(emoji_item(Emoji.find_by_alias(code))) unless is_image_only(Emoji.find_by_alias(code))
     end
 
     puts fb.to_xml(ARGV)

--- a/workflow/main.rb
+++ b/workflow/main.rb
@@ -23,10 +23,9 @@ def emoji_item(emoji)
 end
 
 def is_image_only(emoji)
+    is_image = false
   if emoji.image_filename == "#{emoji.name}.png"
       is_image = true
-  else
-      is_image = false
   end
   is_image
 end

--- a/workflow/main.rb
+++ b/workflow/main.rb
@@ -38,7 +38,8 @@ Alfred.with_friendly_error do |alfred|
     query = Regexp.escape(ARGV.first)
 
     items = Emoji.all.map(&:name).grep(/#{query}/).each do |code|
-      fb.add_item(emoji_item(Emoji.find_by_alias(code))) unless is_image_only(Emoji.find_by_alias(code))
+      emoji_by_alias = Emoji.find_by_alias(code)
+      fb.add_item(emoji_item(emoji_by_alias)) unless is_image_only(emoji_by_alias)
     end
 
     puts fb.to_xml(ARGV)

--- a/workflow/main.rb
+++ b/workflow/main.rb
@@ -23,11 +23,7 @@ def emoji_item(emoji)
 end
 
 def is_image_only(emoji)
-    is_image = false
-  if emoji.image_filename == "#{emoji.name}.png"
-      is_image = true
-  end
-  is_image
+    emoji.image_filename == "#{emoji.name}.png"
 end
 
 Alfred.with_friendly_error do |alfred|


### PR DESCRIPTION
For #3, this compares the emoji name to the images folder, and if it's a match
it'll skip it for the workflow. This prevents non-standard emoji image hacks 
like "bowtie" or "metal" from being returned as just the string.